### PR TITLE
Fix diagnostic line detection

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,8 +55,9 @@ export function activate(context: vscode.ExtensionContext) {
 			const diagnostics: vscode.Diagnostic[] = [];
 			for (const key of missingKeys) {
 				const text = document.getText();
-				const line = text.split('\n').findIndex(l => l.includes('{')); // crude fallback to line 1
-				const range = new vscode.Range(line, 0, line, 0);
+                                const lineIndex = text.split('\n').findIndex(l => l.includes('{'));
+                                const effectiveLine = lineIndex !== -1 ? lineIndex : 0;
+                                const range = new vscode.Range(effectiveLine, 0, effectiveLine, 0);
 				diagnostics.push(new vscode.Diagnostic(range, `Missing key: ${key}`, vscode.DiagnosticSeverity.Warning));
 			}
 			diagnosticCollection.set(document.uri, diagnostics);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,13 +2,14 @@
 	"compilerOptions": {
 		"module": "Node16",
 		"target": "ES2022",
-		"outDir": "out",
-		"lib": [
-			"ES2022"
-		],
-		"sourceMap": true,
-		"rootDir": "src",
-		"strict": true,   /* enable all strict type-checking options */
+                "outDir": "out",
+                "lib": [
+                        "ES2022"
+                ],
+                "types": ["node", "vscode"],
+                "sourceMap": true,
+                "rootDir": "src",
+                "strict": true,   /* enable all strict type-checking options */
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */


### PR DESCRIPTION
## Summary
- avoid negative diagnostic ranges by defaulting to line 0 when none is found
- include Node and VS Code types in TypeScript config

## Testing
- `npm test` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684f118418ac832d9576f6b0b6b14a94